### PR TITLE
Feature/hgi 7585 - Support replication keys and state on Report Streams

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -135,9 +135,8 @@ class GoogleAdsStream(RESTStream):
         params: dict = {}
         if next_page_token:
             params["pageToken"] = next_page_token
-        if self.replication_key:
-            params["sort"] = "asc"
-            params["order_by"] = self.replication_key
+        if self.gaql:
+            params["query"] = self.gaql(context)
         return params
 
     def get_records(self, context):
@@ -152,16 +151,13 @@ class GoogleAdsStream(RESTStream):
 
     @property
     def path(self) -> str:
-        # Paramas
-        path = "/customers/{customer_id}/googleAds:search?query="
-        return path + self.gaql
+        path = "/customers/{customer_id}/googleAds:search"
+        return path
 
-    @cached_property
-    def start_date(self):
-        try:
-            return datetime.fromisoformat(self.config["start_date"]).strftime(r"'%Y-%m-%d'")
-        except Exception:
-            return datetime.strptime(self.config["start_date"], "%Y-%m-%dT%H:%M:%SZ").strftime(r"'%Y-%m-%d'")
+    def start_date(self, context=None):
+        start_value = self.get_starting_replication_key_value(context)
+        start_date =  f"'{parse(start_value).date()}'"
+        return start_date
 
     @cached_property
     def end_date(self):

--- a/tap_googleads/schemas/adgroups_performance.json
+++ b/tap_googleads/schemas/adgroups_performance.json
@@ -24,6 +24,10 @@
         },
         "metrics__impressions": {
             "type": ["string", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"],
+            "format": "date"
         }
     }
 }

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
-from singer_sdk.helpers._state import increment_state
 from tap_googleads.client import GoogleAdsStream, ResumableAPIError, _sanitise_customer_id
 from pendulum import parse
 

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -151,6 +151,8 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
 class ReportsStream(GoogleAdsStream):
     parent_stream_type = CustomerHierarchyStream
+    replication_key = "segments__date"
+
 
     def get_records(self, context):
         records =  super().get_records(context)
@@ -408,7 +410,7 @@ class AdGroupsPerformance(ReportsStream):
     records_jsonpath = "$.results[*]"
     name = "stream_adgroupsperformance"
     primary_keys = ["campaign__id", "adGroup__id"]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "adgroups_performance.json"
 
 
@@ -429,7 +431,7 @@ class CampaignPerformance(ReportsStream):
         "segments__date",
         "segments__device",
     ]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "campaign_performance.json"
 
 
@@ -452,7 +454,7 @@ class CampaignPerformanceByAgeRangeAndDevice(ReportsStream):
         "campaign__status",
         "segments__device",
     ]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_age_range_and_device.json"
 
 
@@ -475,7 +477,7 @@ class CampaignPerformanceByGenderAndDevice(ReportsStream):
         "campaign__status",
         "segments__device",
     ]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_gender_and_device.json"
 
 
@@ -495,7 +497,7 @@ class CampaignPerformanceByLocation(ReportsStream):
         "campaign__name",
         "segments__date",
     ]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_location.json"
 
 
@@ -529,5 +531,5 @@ class GeoPerformance(ReportsStream):
         "campaign__status",
         "segments__date"
     ]
-    replication_key = "segments__date"
+    
     schema_filepath = SCHEMAS_DIR / "geo_performance.json"


### PR DESCRIPTION
Supports the correct use of replication keys and state in Report streams.

The parent ReportsStream now implements `segment__date` as a replication_key.

The `start_date` function now retrieves the `start_date` from SingerSDK's get_latest_replication_key_value function

Because a nested value is used as a replication key (`segments.date`), we modify the post_processing function in the `ReportsStream` to flatten records before incrementing the state so that `segments.date` is denested as `segments__date`